### PR TITLE
Added from __future__ import absolute_import to mklrand.pyx

### DIFF
--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -24,6 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
 include "numpy.pxd"
 
 cdef extern from "Python.h":


### PR DESCRIPTION
This is to work around the error

```
ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
```

seen while loading `mkl_random` from within numpy's test-suite, as per [comments in Cython issue 1720](https://github.com/cython/cython/issues/1720#issuecomment-304590138).