### PR TITLE
use inequality instead of not identity for algo check

### DIFF
--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -1181,7 +1181,7 @@ cdef class RandomState:
             if(err):
                 raise ValueError('The stream state buffer is corrupted')
             brng_id = irk_get_brng_mkl(self.internal_state)
-            if (_brng_dict[algorithm_name] is not brng_id):
+            if (_brng_dict[algorithm_name] != brng_id):
                 raise ValueError('The algorithm name does not match content of the buffer')
 
     # Pickling support:


### PR DESCRIPTION
As discussed on Flowdock, this fixes a failure that seemed to only occur with Python 2.7 and Linux-32.