### PR TITLE
Bugfix/wald

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ install:
   - g++ -v
 
 script:
-  - conda build -c intel -c conda-forge --numpy=1.16 $PYVER conda-recipe
+  - conda build -c intel -c conda-forge --override-channels $PYVER conda-recipe

--- a/mkl_random/setup.py
+++ b/mkl_random/setup.py
@@ -70,12 +70,16 @@ def configuration(parent_package='',top_path=None):
     pdir = 'mkl_random'
     wdir = join(pdir, 'src')
 
+    eca = [Q + 'std=c++11']
+    if sys.platform == "linux":
+        eca.extend(["-Wno-unused-but-set-variable", "-Wno-unused-function"])
+
     config.add_library(
         'mkl_dists',
         sources=join(wdir, 'mkl_distributions.cpp'),
         libraries=libs,
         include_dirs=[wdir,pdir,get_numpy_include(),get_python_include()],
-        extra_compiler_args=[Q + 'std=c++11'],
+        extra_compiler_args=eca,
         depends=[join(wdir, '*.h'),],
         language='c++',
     )

--- a/mkl_random/src/mkl_distributions.cpp
+++ b/mkl_random/src/mkl_distributions.cpp
@@ -433,7 +433,7 @@ irk_pareto_vec(irk_state *state, npy_intp len, double *res, const double alp)
 void
 irk_weibull_vec(irk_state *state, npy_intp len, double *res, const double alp)
 {
-    int i, err;
+    int err;
     const double d_zero = 0.0, d_one = 1.0;
     double rec_alp = 1.0/alp;
 
@@ -458,7 +458,7 @@ irk_weibull_vec(irk_state *state, npy_intp len, double *res, const double alp)
 void
 irk_power_vec(irk_state *state, npy_intp len, double *res, const double alp)
 {
-    int i, err;
+    int err;
     const double d_zero = 0.0, d_one = 1.0;
     double rec_alp = 1.0/alp;
 
@@ -534,7 +534,7 @@ void
 irk_f_vec(irk_state *state, npy_intp len, double *res, const double df_num, const double df_den)
 {
     int err;
-    const double d_zero = 0.0, d_one = 1.0;
+    const double d_zero = 0.0;
     double shape = 0.5*df_num, scale = 2.0/df_num;
     double *den = NULL;
 
@@ -642,7 +642,6 @@ irk_noncentral_chisquare_vec(irk_state *state, npy_intp len, double *res, const 
                 for(i = 0; i < len; ) {
                     int k, j, cv = pvec[idx[i]];
 
-                    DIST_PRAGMA_VECTOR
                     for(j=i+1; (j < len) && (pvec[idx[j]] == cv); j++) {}
 
                     assert(j > i);
@@ -728,7 +727,7 @@ void
 irk_logistic_vec(irk_state *state, npy_intp len, double *res, const double loc, const double scale)
 {
     int i, err;
-    const double d_one = 1.0, d_mone = -1.0, d_zero = 0.0;
+    const double d_one = 1.0, d_zero = 0.0;
 
     if(len < 1)
         return;
@@ -862,7 +861,7 @@ irk_wald_vec(irk_state *state, npy_intp len, double *res, const double mean, con
 static void
 irk_vonmises_vec_small_kappa(irk_state *state, npy_intp len, double *res, const double mu, const double kappa)
 {
-    int i, err, n, size, blen = 1 << 20;
+    int i, err, n, size;
     double rho_over_kappa, rho, r, s_kappa, Z, W, Y, V;
     double *Uvec = NULL, *Vvec = NULL;
     float *VFvec = NULL;
@@ -923,9 +922,9 @@ irk_vonmises_vec_small_kappa(irk_state *state, npy_intp len, double *res, const 
 static void
 irk_vonmises_vec_large_kappa(irk_state *state, npy_intp len, double *res, const double mu, const double kappa)
 {
-    int i, err, n, size, blen = 1 << 20;
+    int i, err, n, size;
     double r_over_two_kappa, recip_two_kappa;
-    double s_minus_one, hpt, r_over_two_kappa_minus_one, rho_minus_one, neg_W_minus_one;
+    double s_minus_one, hpt, r_over_two_kappa_minus_one, rho_minus_one;
     double *Uvec = NULL, *Vvec = NULL;
     float *VFvec = NULL;
     const double d_zero = 0.0, d_one = 1.0;
@@ -1000,8 +999,6 @@ irk_vonmises_vec_large_kappa(irk_state *state, npy_intp len, double *res, const 
 void
 irk_vonmises_vec(irk_state *state, npy_intp len, double *res, const double mu, const double kappa)
 {
-    int blen = 1 << 20;
-
     if(len < 1)
         return;
 
@@ -1022,7 +1019,7 @@ irk_vonmises_vec(irk_state *state, npy_intp len, double *res, const double mu, c
 void
 irk_noncentral_f_vec(irk_state *state, npy_intp len, double *res, const double df_num, const double df_den, const double nonc)
 {
-    int i, blen = 1 << 20;
+    int i;
     double *den = NULL, fctr;
 
     if(len < 1)
@@ -1281,7 +1278,7 @@ irk_poisson_vec_POISNORM(irk_state *state, npy_intp len, int *res, const double 
 void
 irk_poisson_vec_V(irk_state *state, npy_intp len, int *res, double *lambdas)
 {
-    int err, blen;
+    int err;
 
     if(len < 1)
         return;
@@ -1304,7 +1301,7 @@ irk_poisson_vec_V(irk_state *state, npy_intp len, int *res, double *lambdas)
 void
 irk_zipf_long_vec(irk_state *state, npy_intp len, long *res, const double a)
 {
-    int i, err, n_accepted, batch_size, blen = 1 << 20;
+    int i, err, n_accepted, batch_size;
     double T, U, V, am1, b;
     double *Uvec = NULL, *Vvec = NULL;
     long X;
@@ -1897,7 +1894,6 @@ void
 irk_rand_int64_vec(irk_state *state, npy_intp len, npy_int64 *res, const npy_int64 lo, const npy_int64 hi)
 {
     npy_uint64 rng;
-    int err;
     npy_intp i;
 
     if (len < 1)

--- a/mkl_random/src/mkl_distributions.cpp
+++ b/mkl_random/src/mkl_distributions.cpp
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2017-2019, Intel Corporation
+ Copyright (c) 2017-2021, Intel Corporation
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:

--- a/mkl_random/tests/test_random.py
+++ b/mkl_random/tests/test_random.py
@@ -890,9 +890,11 @@ class TestRandomDist_Intel(TestCase):
     def test_wald(self):
         rnd.seed(self.seed, brng=self.brng)
         actual = rnd.wald(mean=1.23, scale=1.54, size=(3, 2))
-        desired = np.array([[0.3465678392232347, 0.3594497155916536],
-                            [2.192908727996422, 1.7408141717513501],
-                            [1.1943709105062374, 0.3273455943060196]])
+        desired = np.array(
+            [[0.22448558337033758, 0.23485255518098838],
+             [2.756850184899666, 2.005347850108636],
+             [1.179918636588408, 0.20928649815442452]
+            ])
         np.testing.assert_array_almost_equal(actual, desired, decimal=10)
 
     def test_weibull(self):

--- a/mkl_random/tests/test_regression.py
+++ b/mkl_random/tests/test_regression.py
@@ -170,5 +170,10 @@ class TestRegression_Intel(TestCase):
         gc.collect()
 
 
+    def test_non_central_chi_squared_df_one(self):
+        a = rnd.noncentral_chisquare(df = 1.0, nonc=2.3, size=10**4)
+        assert(a.min() > 0.0)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
@samir-nasibli 

This fixes incorrect sampling in Wald, a.k.a Inverse Gaussian distribution.

```python
(mkl_random_dev) [16:32:33 lin03 mkl_random]$ ipython
Python 3.6.8 |Intel Corporation| (default, Apr 12 2019, 17:34:58)
Type 'copyright', 'credits' or 'license' for more information
IPython 6.3.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import mkl_random, numpy as np

In [2]: wald_sample = mkl_random.wald(mean=14, scale=15, size=5*10**6)

In [3]: np.mean(wald_sample)
Out[3]: 14.007203796988938

In [4]: np.var(wald_sample)
Out[4]: 183.2745041415038

In [5]: np.mean(np.logical_and(13 < wald_sample, wald_sample < 17))
Out[5]: 0.1069688
```

All sample expectations agree with population expectations.