### PR TITLE
Support ARS5 counter-based basic random number generator provided by MKL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 `mkl_random` has started as Intel (R) Distribution for Python optimizations for NumPy.
 
-Per NumPy's community suggestions, voiced in https://github.com/numpy/numpy/pull/8209, it is being released as a 
+Per NumPy's community suggestions, voiced in https://github.com/numpy/numpy/pull/8209, it is being released as a
 stand-alone package.
 
 Prebuilt `mkl_random` can be installed into conda environment from Intel's channel on Anaconda cloud:
@@ -20,7 +20,7 @@ For distributions directly supported in Intel (R) Math Kernel Library (MKL), `me
    mkl_random.standard_normal(size=(10**5, 10**3), method='BoxMuller')
 ```
 
-Additionally, `mkl_random` exposes different basic random number generation algorithms available in MKL. For example to use `SFMT19937` use 
+Additionally, `mkl_random` exposes different basic random number generation algorithms available in MKL. For example to use `SFMT19937` use
 
 ```
    mkl_random.RandomState(77777, brng='SFMT19937')
@@ -28,5 +28,19 @@ Additionally, `mkl_random` exposes different basic random number generation algo
 
 For generator families, such that `MT2203` and Wichmann-Hill, a particular member of the family can be chosen by specifying ``brng=('WH', 3)``, etc.
 
-See MKL reference guide for more details: 
+See MKL reference guide for more details:
    https://software.intel.com/en-us/mkl-developer-reference-c-random-number-generators
+
+The list of supported by `mkl_random.RandomState` constructor `brng` keywords is as follows:
+
+  * 'MT19937'
+  * 'SFMT19937'
+  * 'WH' or ('WH', id)
+  * 'MT2203' or ('MT2203', id)
+  * 'MCG31'
+  * 'R250'
+  * 'MRG32K3A'
+  * 'MCG59'
+  * 'PHILOX4X32X10'
+  * 'NONDETERM'
+  * 'ARS5'

--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -70,6 +70,7 @@ cdef extern from "randomkit.h":
         MCG59 = 7
         PHILOX4X32X10 = 8
         NONDETERM = 9
+        ARS5 = 10
 
     void irk_fill(void *buffer, size_t size, irk_state *state) nogil
 
@@ -873,6 +874,7 @@ _brng_dict = {
     'NONDETERM' : NONDETERM,
     'NONDETERMINISTIC' : NONDETERM,
     'NON_DETERMINISTIC' : NONDETERM,
+    'ARS5' : ARS5
 }
 
 _brng_dict_stream_max = {
@@ -886,6 +888,7 @@ _brng_dict_stream_max = {
     MCG59: 1,
     PHILOX4X32X10: 1,
     NONDETERM: 1,
+    ARS5: 1,
 }
 
 cdef irk_brng_t _default_fallback_brng_token_(brng):
@@ -973,8 +976,8 @@ cdef class RandomState:
         If `seed` is ``None``, then `RandomState` will try to read data from
         ``/dev/urandom`` (or the Windows analogue) if available or seed from
         the clock otherwise.
-    brng : {'MT19937', 'SFMT19937', 'MT2203', 'R250', 'WH', 'MCG31',
-            'MCG59', 'MRG32K3A', 'PHILOX4X32X10', 'NONDETERM'}, optional
+    brng : {'MT19937', 'SFMT19937', 'MT2203', 'R250', 'WH', 'MCG31', 'MCG59',
+            'MRG32K3A', 'PHILOX4X32X10', 'NONDETERM', 'ARS5'}, optional
         Basic pseudo-random number generation algorithms, provided by
         Intel MKL. The default choice is 'MT19937' - the Mersenne Twister.
 
@@ -1023,7 +1026,8 @@ cdef class RandomState:
             Seed for `RandomState`.
             Must be convertible to 32 bit unsigned integers.
         brng : {'MT19937', 'SFMT19937', 'MT2203', 'R250', 'WH', 'MCG31',
-                'MCG59', 'MRG32K3A', 'PHILOX4X32X10', 'NONDETERM', None}, optional
+                'MCG59', 'MRG32K3A', 'PHILOX4X32X10', 'NONDETERM',
+                'ARS5', None}, optional
             Basic pseudo-random number generation algorithms, provided by
             Intel MKL. Use `brng==None` to keep the `brng` specified to construct
             the class instance.

--- a/mkl_random/src/randomkit.c
+++ b/mkl_random/src/randomkit.c
@@ -24,7 +24,7 @@
  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-/* 
+/*
  Adopted from NumPy's Random kit 1.3,
  Copyright (c) 2003-2005, Jean-Sebastien Roy (js@jeannot.org)
  */
@@ -119,10 +119,11 @@ const MKL_INT brng_list[BRNG_KINDS] = {
     VSL_BRNG_MRG32K3A,
     VSL_BRNG_MCG59,
     VSL_BRNG_PHILOX4X32X10,
-    VSL_BRNG_NONDETERM
+    VSL_BRNG_NONDETERM,
+    VSL_BRNG_ARS5
 };
 
-/* Mersenne-Twister 2203 algorithm and Wichmann-Hill algorithm 
+/* Mersenne-Twister 2203 algorithm and Wichmann-Hill algorithm
  * each have a parameter which produces a family of BRNG algorithms,
  * MKL identifies individual members of these families by VSL_BRNG_ALGO + family_id
  */

--- a/mkl_random/src/randomkit.h
+++ b/mkl_random/src/randomkit.h
@@ -45,7 +45,7 @@ typedef enum {
 } irk_error;
 
 /* if changing this, also adjust brng_list[BRNG_KINDS] in randomkit.c */
-#define BRNG_KINDS 10
+#define BRNG_KINDS 11
 
 typedef enum {
     MT19937       = 0,
@@ -57,7 +57,8 @@ typedef enum {
     MRG32K3A      = 6,
     MCG59         = 7,
     PHILOX4X32X10 = 8,
-    NONDETERM     = 9
+    NONDETERM     = 9,
+    ARS5          = 10
 } irk_brng_t;
 
 


### PR DESCRIPTION
See:

https://software.intel.com/content/www/us/en/develop/documentation/onemkl-vsnotes/top/testing-of-basic-random-number-generators/basic-random-generator-properties-and-testing-results/ars5.html

In Python

```python
import mkl_random
rs = mkl_random.RandomState(1234, brng="ARS5")
rs.randn(5)
```