### PR TITLE
Fix sat 5359

### DIFF
--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -1953,7 +1953,7 @@ cdef class RandomState:
                     raise ValueError("Fewer non-zero entries in p than size")
                 n_uniq = 0
                 p = p.copy()
-                found = np.zeros(shape, dtype=np.int)
+                found = np.zeros(tuple() if shape is None else shape, dtype=np.int64)
                 flat_found = found.ravel()
                 while n_uniq < size:
                     x = self.rand(size - n_uniq)
@@ -5250,7 +5250,7 @@ cdef class RandomState:
         [True, True]
 
         """
-        from numpy.dual import svd
+        from numpy.linalg import svd
 
         # Check preconditions on arguments
         mean = np.array(mean)

--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -426,7 +426,7 @@ cdef object vec_disc0_array(irk_state *state, irk_disc0_vec func, object size,
         return array
 
 cdef object vec_long_disc0_array(
-    irk_state *state, irk_disc0_vec_long func, 
+    irk_state *state, irk_disc0_vec_long func,
     object size, object lock
 ):
     cdef long *array_data
@@ -5044,7 +5044,7 @@ cdef class RandomState:
             raise ValueError("nbad < 0")
         if np.any(np.less(onsample, 1)):
             raise ValueError("nsample < 1")
-        otot = np.add(ongood, onbad);
+        otot = np.asarray(np.add(ongood, onbad));
         if np.any(np.less_equal(otot, 0)):
             raise ValueError("Number of balls in each urn should not exceed 2147483647")
         if np.any(np.less(otot,onsample)):

--- a/mkl_random/tests/test_random.py
+++ b/mkl_random/tests/test_random.py
@@ -126,7 +126,7 @@ class TestMultinomial_Intel(TestCase):
                      (2, 2, 2))
 
         assert_raises(TypeError, rnd.multinomial, 1, p,
-                      np.float(1))
+                      np.float64(1))
 
 
 class TestSetState_Intel(TestCase):
@@ -185,7 +185,7 @@ class TestRandint_Intel(TestCase):
              np.int32, np.uint32, np.int64, np.uint64]
 
     def test_unsupported_type(self):
-        assert_raises(TypeError, self.rfunc, 1, dtype=np.float)
+        assert_raises(TypeError, self.rfunc, 1, dtype=np.float64)
 
     def test_bounds_checking(self):
         for dt in self.itype:
@@ -215,7 +215,7 @@ class TestRandint_Intel(TestCase):
                 vals = self.rfunc(2, ubnd, size=2**16, dtype=dt)
                 assert_(vals.max() < ubnd)
                 assert_(vals.min() >= 2)
-        vals = self.rfunc(0, 2, size=2**16, dtype=np.bool)
+        vals = self.rfunc(0, 2, size=2**16, dtype='bool')
         assert_(vals.max() < 2)
         assert_(vals.min() >= 0)
 
@@ -244,14 +244,13 @@ class TestRandint_Intel(TestCase):
                 val = self.rfunc(0, 6, size=1000, dtype=dt).byteswap()
 
             res = hashlib.md5(val.view(np.int8)).hexdigest()
-            print("")
             assert_(tgt[np.dtype(dt).name] == res)
 
         # bools do not depend on endianess
         rnd.seed(1234, brng='MT19937')
-        val = self.rfunc(0, 2, size=1000, dtype=np.bool).view(np.int8)
+        val = self.rfunc(0, 2, size=1000, dtype='bool').view(np.int8)
         res = hashlib.md5(val).hexdigest()
-        assert_(tgt[np.dtype(np.bool).name] == res)
+        assert_(tgt[np.dtype('bool').name] == res)
 
     def test_respect_dtype_singleton(self):
         # See gh-7203
@@ -262,9 +261,9 @@ class TestRandint_Intel(TestCase):
             sample = self.rfunc(lbnd, ubnd, dtype=dt)
             self.assertEqual(sample.dtype, np.dtype(dt))
 
-        for dt in (np.bool, np.int, np.long):
-            lbnd = 0 if dt is np.bool else np.iinfo(dt).min
-            ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
+        for dt in (bool, int):
+            lbnd = 0 if dt is bool else np.iinfo(np.dtype(dt)).min
+            ubnd = 2 if dt is bool else np.iinfo(np.dtype(dt)).max + 1
 
             # gh-7284: Ensure that we get Python data types
             sample = self.rfunc(lbnd, ubnd, dtype=dt)
@@ -527,7 +526,7 @@ class TestRandomDist_Intel(TestCase):
         assert_equal(rnd.dirichlet(p, (2, 2)).shape, (2, 2, 2))
         assert_equal(rnd.dirichlet(p, np.array((2, 2))).shape, (2, 2, 2))
 
-        assert_raises(TypeError, rnd.dirichlet, p, np.float(1))
+        assert_raises(TypeError, rnd.dirichlet, p, np.float64(1))
 
 
     def test_exponential(self):


### PR DESCRIPTION
This PR addresses NumPy's deprecations as well as works around stricter checks Cython makes with Python 3.10 for assignment to variable of `ndarray` Cython class. Assignments of NumPy scalars are no longer allowed. The solution is to insert an explicit conversion to array (`np.asarray`). 