### PR TITLE
Fix osx build

### DIFF
--- a/.github/workflows/build-with-clang.yml
+++ b/.github/workflows/build-with-clang.yml
@@ -1,0 +1,70 @@
+name: Build mkl_random with clang
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  generate-coverage:
+    name: Generate coverage and push to Coveralls.io
+    runs-on: ubuntu-latest
+
+    env:
+      ONEAPI_ROOT: /opt/intel/oneapi
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Add Intel repository
+        run: |
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+          sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+          sudo apt-get update
+
+      - name: Install Intel OneAPI
+        run: |
+          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
+          sudo apt-get install intel-oneapi-tbb
+          sudo apt-get install intel-oneapi-mkl-devel
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: x64
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install mkl_random dependencies
+        shell: bash -l {0}
+        run: |
+          pip install numpy cython setuptools pytest pytest-cov
+
+      - name: List oneAPI folder content
+        shell: bash -l {0}
+        run: ls /opt/intel/oneapi/compiler
+
+      - name: Build mkl_random
+        shell: bash -l {0}
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          echo $CMPLR_ROOT
+          export CC=$CMPLR_ROOT/../latest/bin-llvm/clang
+          export CXX=$CMPLR_ROOT/../latest/bin-llvm/clang++
+          echo "CC = ${CC}  CXX=${CXX}"
+	  ls -l ${CC} ${CXX}
+          python setup.py develop
+
+      - name: Run mkl_random tests
+        shell: bash -l {0}
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          pytest -s -v --pyargs mkl_random

--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -1212,6 +1212,7 @@ cdef class RandomState:
         self.set_state(state)
 
     def __reduce__(self):
+        global __RandomState_ctor
         return (__RandomState_ctor, (), self.get_state())
 
     def leapfrog(self, int k, int nstreams):

--- a/mkl_random/src/mkl_distributions.cpp
+++ b/mkl_random/src/mkl_distributions.cpp
@@ -44,6 +44,10 @@
 #define DIST_PRAGMA_VECTOR _Pragma("vector")
 #define DIST_PRAGMA_NOVECTOR _Pragma("novector")
 #define DIST_ASSUME_ALIGNED(p, b) __assume_aligned((p), (b));
+#elif defined(__clang__)
+#define DIST_PRAGMA_VECTOR _Pragma("clang loop vectorize(enable)")
+#define DIST_PRAGMA_NOVECTOR _Pragma("clang loop vectorize(disable)")
+#define DIST_ASSUME_ALIGNED(p, b)
 #elif defined(__GNUG__)
 #define DIST_PRAGMA_VECTOR _Pragma("GCC ivdep")
 #define DIST_PRAGMA_NOVECTOR

--- a/mkl_random/src/randomkit.cpp
+++ b/mkl_random/src/randomkit.cpp
@@ -90,7 +90,7 @@
 #define RK_DEV_RANDOM "/dev/random"
 #endif
 
-char *irk_strerror[RK_ERR_MAX] =
+const char *irk_strerror[RK_ERR_MAX] =
     {
         "no error",
         "random device unvavailable"};
@@ -350,7 +350,7 @@ void irk_random_vec(irk_state *state, const int len, unsigned int *res)
 void irk_fill(void *buffer, size_t size, irk_state *state)
 {
     unsigned int r;
-    unsigned char *buf = buffer;
+    unsigned char *buf = reinterpret_cast<unsigned char *>(buffer);
     int err, len;
 
     /* len = size / 4 */

--- a/mkl_random/src/randomkit.h
+++ b/mkl_random/src/randomkit.h
@@ -63,7 +63,7 @@ typedef enum {
 
 
 /* error strings */
-extern char *irk_strerror[RK_ERR_MAX];
+extern const char *irk_strerror[RK_ERR_MAX];
 
 /* Maximum generated random value */
 #define RK_MAX 0xFFFFFFFFUL

--- a/mkl_random/tests/test_random.py
+++ b/mkl_random/tests/test_random.py
@@ -29,7 +29,7 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 from unittest import TestCase
 from numpy.testing import (
-        run_module_suite, assert_, assert_raises, assert_equal,
+        assert_, assert_raises, assert_equal,
         assert_warns, suppress_warnings)
 import mkl_random as rnd
 from numpy.compat import asbytes
@@ -952,7 +952,3 @@ class TestThread_Intel(TestCase):
         def gen_random(state, out):
             out[...] = state.multinomial(10, [1/6.]*6, size=10000)
         self.check_function(gen_random, sz=(10000,6))
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/mkl_random/tests/test_regression.py
+++ b/mkl_random/tests/test_regression.py
@@ -25,9 +25,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import sys
-from numpy.testing import (TestCase, run_module_suite, assert_,
-                           assert_array_equal, assert_raises, dec)
-import mkl
+from numpy.testing import (TestCase, assert_,
+                           assert_array_equal, assert_raises)
 import mkl_random as rnd
 from numpy.compat import long
 import numpy as np
@@ -117,8 +116,6 @@ class TestRegression_Intel(TestCase):
         rnd.multivariate_normal([0], [[0]], size=np.int_(1))
         rnd.multivariate_normal([0], [[0]], size=np.int64(1))
 
-#    @dec.skipif(tuple(map(mkl.get_version().get, ['MajorVersion', 'UpdateVersion'])) == (2020,3),
-#                msg="Intel(R) MKL 2020.3 produces NaN for these parameters")
     def test_beta_small_parameters(self):
         # Test that beta with small a and b parameters does not produce
         # NaNs due to roundoff errors causing 0 / 0, gh-5851
@@ -173,7 +170,3 @@ class TestRegression_Intel(TestCase):
     def test_non_central_chi_squared_df_one(self):
         a = rnd.noncentral_chisquare(df = 1.0, nonc=2.3, size=10**4)
         assert(a.min() > 0.0)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ def extensions():
             [
                 os.path.join("mkl_random", "mklrand.pyx"),
                 os.path.join("mkl_random", "src", "mkl_distributions.cpp"),
-                os.path.join("mkl_random", "src", "randomkit.c"),
+                os.path.join("mkl_random", "src", "randomkit.cpp"),
             ],
             depends = [
                 os.path.join("mkl_random", "src", "mkl_distributions.hpp"),


### PR DESCRIPTION
Renamed "randomkit.c" to "randomkit.cpp", fixed renamed some `char *` to `const char *` per errors.

Fixed tests to avoid importing removed qualifiers from `numpy.testing`.