### PR TITLE
Allow action to push to gh-pages

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -73,8 +73,9 @@ jobs:
       - name: Checkout gh-pages
         if: ${{ !github.event.pull_request && github.event.action != 'closed'}}
         run: |
+          git remote add tokened_docs https://IntelPython:${{ secrets.GITHUB_TOKEN }}@github.com/IntelPython/dpctl.git
           git fetch --all
-          git checkout gh-pages
+          git checkout --track tokened_docs/gh-pages
       - name: 'Copy build to root'
         if: ${{ !github.event.pull_request && github.event.action != 'closed'}}
         run: |
@@ -89,5 +90,5 @@ jobs:
       - name: Publish changes
         if: ${{ success() && !github.event.pull_request && github.event.action != 'closed'}}
         run: |
-          git push origin gh-pages
+          git push tokened_docs gh-pages
         timeout-minutes: 10


### PR DESCRIPTION
Create repo that uses github token to acquire permission to push. Unfortunately PR actions will not be able to test it, as it only runs on pushes to the main branch.

Hence, we should make sure that GH is able to start workflows, and merge the fix right away to see if it had any effect on workflows triggered by pushed to main branch. 