### PR TITLE
Support numpy 2.0

### DIFF
--- a/.github/workflows/build-with-clang.yml
+++ b/.github/workflows/build-with-clang.yml
@@ -11,6 +11,10 @@ jobs:
     name: Build project with IntelLLVM clang compiler
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python: ["3.9", "3.10", "3.11", "3.12"]
+        use_pre: ["", "--pre"]
     env:
       ONEAPI_ROOT: /opt/intel/oneapi
 
@@ -37,7 +41,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python }}
           architecture: x64
 
       - name: Checkout repo
@@ -48,7 +52,8 @@ jobs:
       - name: Install mkl_random dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy cython setuptools pytest pytest-cov
+          pip install cython setuptools pytest pytest-cov
+          pip install numpy ${{ use_pre }}
 
       - name: List oneAPI folder content
         shell: bash -l {0}

--- a/.github/workflows/build-with-clang.yml
+++ b/.github/workflows/build-with-clang.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install cython setuptools pytest pytest-cov
-          pip install numpy ${{ use_pre }}
+          pip install numpy ${{ matrix.use_pre }}
 
       - name: List oneAPI folder content
         shell: bash -l {0}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10']
     env:
       conda-bld: C:\Miniconda\conda-bld\win-64\
     steps:
@@ -102,7 +102,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10']
         experimental: [false]
         runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -169,7 +169,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10']
         experimental: [false]
         runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -59,7 +59,7 @@ jobs:
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.tar.bz2
 
   build_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       matrix:
@@ -171,7 +171,7 @@ jobs:
       matrix:
         python: ['3.9', '3.10']
         experimental: [false]
-        runner: [windows-latest]
+        runner: [windows-2019]
     continue-on-error: ${{ matrix.experimental }}
     env:
       CHANNELS: -c conda-forge -c intel --override-channels

--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -1687,7 +1687,7 @@ cdef class RandomState:
             ret = randfunc(low, high - 1, size)
 
         if size is None:
-            if dtype in (bool, int, np.compat.long):
+            if dtype in (bool, int, np.long):
                 return dtype(ret)
 
         return ret
@@ -1893,7 +1893,7 @@ cdef class RandomState:
         """
 
         # Format and Verify input
-        a = np.array(a, copy=False)
+        a = np.asarray(a)
         if a.ndim == 0:
             try:
                 # __index__ must return an integer by python rules.
@@ -1942,7 +1942,7 @@ cdef class RandomState:
                 cdf /= cdf[-1]
                 uniform_samples = self.random_sample(shape)
                 idx = cdf.searchsorted(uniform_samples, side='right')
-                idx = np.array(idx, copy=False) # searchsorted returns a scalar
+                idx = np.asarray(idx) # searchsorted returns a scalar
             else:
                 idx = self.randint(0, pop_size, size=shape)
         else:

--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -1687,7 +1687,7 @@ cdef class RandomState:
             ret = randfunc(low, high - 1, size)
 
         if size is None:
-            if dtype in (bool, int, np.long):
+            if dtype in (bool, int):
                 return dtype(ret)
 
         return ret

--- a/mkl_random/tests/test_random.py
+++ b/mkl_random/tests/test_random.py
@@ -31,7 +31,6 @@ import mkl_random as rnd
 from numpy.testing import (
         assert_, assert_raises, assert_equal,
         assert_warns, suppress_warnings)
-from numpy.compat import asbytes
 import sys
 import warnings
 
@@ -500,7 +499,7 @@ def test_choice_return_shape():
 def test_randomdist_bytes(randomdist):
     rnd.seed(randomdist.seed, brng=randomdist.brng)
     actual = rnd.bytes(10)
-    desired = asbytes('\xa4\xde\xde{\xb4\x88\xe6\x84*2')
+    desired = b'\xa4\xde\xde{\xb4\x88\xe6\x84*2'
     np.testing.assert_equal(actual, desired)
 
 

--- a/mkl_random/tests/test_regression.py
+++ b/mkl_random/tests/test_regression.py
@@ -79,7 +79,7 @@ def test_permutation_longs():
     rnd.seed(1234, brng='MT19937')
     dt_long = np.dtype("long")
     twelve_long = dt_long.type(12)
-    b = rnd.permutation(twelse_long)
+    b = rnd.permutation(twelve_long)
     assert_array_equal(a, b)
 
 

--- a/mkl_random/tests/test_regression.py
+++ b/mkl_random/tests/test_regression.py
@@ -29,7 +29,6 @@ from numpy.testing import (TestCase, assert_,
                            assert_array_equal, assert_raises)
 import mkl_random as rnd
 import numpy as np
-from numpy import long
 
 import pytest
 import gc
@@ -78,7 +77,9 @@ def test_permutation_longs():
     rnd.seed(1234, brng='MT19937')
     a = rnd.permutation(12)
     rnd.seed(1234, brng='MT19937')
-    b = rnd.permutation(long(12))
+    dt_long = np.dtype("long")
+    twelve_long = dt_long.type(12)
+    b = rnd.permutation(twelse_long)
     assert_array_equal(a, b)
 
 

--- a/mkl_random/tests/test_regression.py
+++ b/mkl_random/tests/test_regression.py
@@ -28,8 +28,8 @@ import sys
 from numpy.testing import (TestCase, assert_,
                            assert_array_equal, assert_raises)
 import mkl_random as rnd
-from numpy.compat import long
 import numpy as np
+from numpy import long
 
 import pytest
 import gc

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,10 @@ License :: OSI Approved
 Programming Language :: C
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.7
-Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development
 Topic :: Scientific/Engineering
@@ -95,7 +95,8 @@ def extensions():
 
     defs = [('_FILE_OFFSET_BITS', '64'),
             ('_LARGEFILE_SOURCE', '1'),
-            ('_LARGEFILE64_SOURCE', '1')]
+            ('_LARGEFILE64_SOURCE', '1'),
+            ("PY_ARRAY_UNIQUE_SYMBOL", "mkl_random_ext")]
 
     exts = [
         Extension(


### PR DESCRIPTION
Changes to support NumPy 2.0

These are minor, removal of use of `np.compat`, use of `np.asarray(x)` instead of `np.array(x, copy=False)`.