### PR TITLE
Support mkl_random in virtual environment out of the box

### DIFF
--- a/mkl_random/__init__.py
+++ b/mkl_random/__init__.py
@@ -26,6 +26,8 @@
 
 from __future__ import division, absolute_import, print_function
 
+from . import _init_helper
+
 from .mklrand import *
 from ._version import __version__
 

--- a/mkl_random/_init_helper.py
+++ b/mkl_random/_init_helper.py
@@ -1,0 +1,30 @@
+# Copyright 2020-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import os.path
+import sys
+
+is_venv_win32 = (
+    sys.platform == "win32"
+    and sys.base_exec_prefix != sys.exec_prefix
+    and os.path.isfile(os.path.join(sys.exec_prefix, "pyvenv.cfg"))
+)
+
+if is_venv_win32:
+    dll_dir = os.path.join(sys.exec_prefix, "Library", "bin")
+    if os.path.isdir(dll_dir):
+        os.add_dll_directory(dll_dir)
+
+del is_venv_win32


### PR DESCRIPTION
Since location of "Library\bin" in the virtual environment is not on the default search path, importing of mkl_random and numpy fails.

This change introduces "_init_helper.py" file which implements the following logic using built-in os Python module:

If os.add_dll_directory attribute exists, and VIRTUAL_ENV environment variable is set, and os.path.join(os.environ["VIRTUAL_ENV"], "Library", "bin") folder exists, call os.add_dll_directory with that directory