### PR TITLE
Use `windows-latest` for GitHub CI

### DIFF
--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -62,7 +62,7 @@ jobs:
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.conda
 
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       matrix:
@@ -177,7 +177,7 @@ jobs:
         python: ["3.9", "3.10", "3.11", "3.12"]
         numpy: ["1.26*", "2*"]
         experimental: [false]
-        runner: [windows-2019]
+        runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}
     env:
       CHANNELS: -c conda-forge --override-channels

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -62,7 +62,7 @@ jobs:
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.conda
 
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       matrix:
@@ -177,7 +177,7 @@ jobs:
         python: ["3.9", "3.10", "3.11", "3.12"]
         numpy: ['1.26*']
         experimental: [false]
-        runner: [windows-2019]
+        runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}
     env:
       CHANNELS: -c conda-forge -c https://software.repos.intel.com/python/conda --override-channels


### PR DESCRIPTION
`windows-2019` image is no longer supported by GH CI runners