### PR TITLE
Fix conda-package workflow

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -21,7 +21,17 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - python: "3.10"
+            numpy: "2.2"
+          - python: "3.11"
+            numpy: "2.3"
+          - python: "3.12"
+            numpy: "2.3"
+          - python: "3.13"
+            numpy: "2.3"
+          - python: "3.14"
+            numpy: "2.3"
 
     steps:
       - name: Cancel Previous Runs
@@ -66,7 +76,7 @@ jobs:
       - name: List base environment packages
         run: |
           conda list -n base
-  
+
       - name: Store conda paths as envs
         shell: bash -el {0}
         run: |
@@ -75,7 +85,7 @@ jobs:
       - name: Build conda package
         run: |
           CHANNELS=(-c https://software.repos.intel.com/python/conda -c conda-forge --override-channels)
-          VERSIONS=(--python "${{ matrix.python }}")
+          VERSIONS=(--python "${{ matrix.python }}" --numpy "${{ matrix.numpy }}")
           TEST=(--no-test)
 
           conda build \
@@ -97,7 +107,17 @@ jobs:
         shell: cmd /C CALL {0}
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - python: "3.10"
+            numpy: "2.2"
+          - python: "3.11"
+            numpy: "2.3"
+          - python: "3.12"
+            numpy: "2.3"
+          - python: "3.13"
+            numpy: "2.3"
+          - python: "3.14"
+            numpy: "2.3"
 
     steps:
       - name: Cancel Previous Runs
@@ -144,7 +164,7 @@ jobs:
           conda list -n base
 
       - name: Build conda package
-        run: conda build --no-test --python "${{ matrix.python }}" -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels conda-recipe
+        run: conda build --no-test --python "${{ matrix.python }}" --numpy "${{ matrix.numpy }}" -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels conda-recipe
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -154,22 +174,13 @@ jobs:
 
   test_linux:
     needs: build_linux
-
-    runs-on:  ubuntu-latest
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        include:
-          - python: "3.10"
-            numpy: "2.2"
-          - python: "3.11"
-            numpy: "2.3"
-          - python: "3.12"
-            numpy: "2.3"
-          - python: "3.13"
-            numpy: "2.3"
-          - python: "3.14"
-            numpy: "2.3"
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        numpy: ['numpy">=2"']
+        experimental: [false]
 
     env:
       CHANNELS: -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels
@@ -214,7 +225,7 @@ jobs:
           . "$CONDA/etc/profile.d/conda.sh"
           PACKAGE_VERSION="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")"
           export PACKAGE_VERSION
-          conda create -n "${{ env.TEST_ENV_NAME }}" "${PACKAGE_NAME}=${PACKAGE_VERSION}" "python=${{ matrix.python }}" "numpy=${{ matrix.numpy }}" -c "$GITHUB_WORKSPACE/channel" -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels --only-deps --dry-run > lockfile
+          conda create -n "${{ env.TEST_ENV_NAME }}" "${PACKAGE_NAME}=${PACKAGE_VERSION}" "python=${{ matrix.python }}" ${{ matrix.numpy }} -c "$GITHUB_WORKSPACE/channel" -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels --only-deps --dry-run > lockfile
           cat lockfile
 
       - name: Set pkgs_dirs
@@ -238,7 +249,7 @@ jobs:
           . "$CONDA/etc/profile.d/conda.sh"
           PACKAGE_VERSION="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")"
           export PACKAGE_VERSION
-          conda create -n "${{ env.TEST_ENV_NAME }}" "${PACKAGE_NAME}=${PACKAGE_VERSION}" pytest "python=${{ matrix.python }}" "numpy=${{ matrix.numpy }}" -c "$GITHUB_WORKSPACE/channel" -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels
+          conda create -n "${{ env.TEST_ENV_NAME }}" "${PACKAGE_NAME}=${PACKAGE_VERSION}" pytest "python=${{ matrix.python }}" ${{ matrix.numpy }} -c "$GITHUB_WORKSPACE/channel" -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels
           conda activate "${{ env.TEST_ENV_NAME }}"
 
           # Test installed packages
@@ -252,22 +263,13 @@ jobs:
 
   test_windows:
     needs: build_windows
-
-    runs-on:  windows-latest
+    runs-on: windows-latest
 
     strategy:
       matrix:
-        include:
-          - python: "3.10"
-            numpy: "2.2"
-          - python: "3.11"
-            numpy: "2.3"
-          - python: "3.12"
-            numpy: "2.3"
-          - python: "3.13"
-            numpy: "2.3"
-          - python: "3.14"
-            numpy: "2.3"
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        numpy: ['numpy">=2"']
+        experimental: [false]
 
     env:
       CHANNELS: -c https://software.repos.intel.com/python/conda -c conda-forge --override-channels
@@ -317,7 +319,7 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} numpy=${{ matrix.numpy }} -c ${{ env.GITHUB_WORKSPACE }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
+          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} ${{ matrix.numpy }} -c ${{ env.GITHUB_WORKSPACE }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
 
       - name: Cache conda packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -343,7 +345,7 @@ jobs:
              SET PACKAGE_VERSION=%%F
           )
           SET "WORKAROUND_DEPENDENCIES=intel-openmp"
-          conda create -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %WORKAROUND_DEPENDENCIES% pytest python=${{ matrix.python }} numpy=${{ matrix.numpy }} -c ${{ env.GITHUB_WORKSPACE }}/channel ${{ env.CHANNELS }}
+          conda create -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %WORKAROUND_DEPENDENCIES% pytest python=${{ matrix.python }} ${{ matrix.numpy }} -c ${{ env.GITHUB_WORKSPACE }}/channel ${{ env.CHANNELS }}
           conda activate ${{ env.TEST_ENV_NAME }}
 
           # Test installed packages

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -13,6 +13,7 @@ env:
   TEST_ENV_NAME: test_mkl_random
   VER_SCRIPT1: "import json; f = open('ver.json', 'r'); j = json.load(f); f.close(); "
   VER_SCRIPT2: "d = j['mkl_random'][0]; print('='.join((d[s] for s in ('version', 'build'))))"
+  CONDA_BUILD_VERSION: 26.3.0
 
 jobs:
   build_linux:
@@ -51,9 +52,21 @@ jobs:
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
 
-      - name: Install conda-build
-        run: conda install conda-build
+      - name: Update conda
+        run: |
+          conda update -n base --all
 
+      - name: Install conda-build
+        run: conda install -n base conda-build=${{ env.CONDA_BUILD_VERSION }} -c conda-forge --override-channels
+
+      - name: Show Conda info
+        run: |
+          conda info --all
+
+      - name: List base environment packages
+        run: |
+          conda list -n base
+  
       - name: Store conda paths as envs
         shell: bash -el {0}
         run: |
@@ -98,10 +111,12 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
+          auto-update-conda: true
           miniforge-version: latest
           activate-environment: build
           channels: conda-forge
           python-version: ${{ matrix.python }}
+          conda-build-version: ${{ env.CONDA_BUILD_VERSION }}
 
       - name: Cache conda packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -120,9 +135,12 @@ jobs:
         run: |
           echo "CONDA_BLD=$CONDA/conda-bld/win-64/" | tr "\\\\" '/' >> "$GITHUB_ENV"
 
-      - name: Install conda build
+      - name: Show Conda info
         run: |
-          conda install -n base -y conda-build
+          conda info --all
+
+      - name: List base environment packages
+        run: |
           conda list -n base
 
       - name: Build conda package
@@ -165,8 +183,21 @@ jobs:
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
 
+      - name: Update conda
+        run: |
+          conda update -n base --all
+
       - name: Install conda-index
-        run: conda install conda-index
+        run: |
+          conda install -n base conda-index -c conda-forge --override-channels
+
+      - name: Show Conda info
+        run: |
+          conda info --all
+
+      - name: List base environment packages
+        run: |
+          conda list -n base
 
       - name: Create conda channel
         run: |
@@ -249,6 +280,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
+          auto-update-conda: true
           miniforge-version: latest
           channels: conda-forge
           activate-environment: ${{ env.TEST_ENV_NAME }}
@@ -256,7 +288,15 @@ jobs:
 
       - name: Install conda-index
         run: |
-          conda install conda-index
+          conda install -n base conda-index
+
+      - name: Show Conda info
+        run: |
+          conda info --all
+
+      - name: List base environment packages
+        run: |
+          conda list -n base
 
       - name: Create conda channel
         run: |

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -304,17 +304,28 @@ jobs:
         run: |
           mkdir ${{ env.GITHUB_WORKSPACE }}\channel\win-64
           move ${{ env.PACKAGE_NAME }}-*.conda ${{ env.GITHUB_WORKSPACE }}\channel\win-64
-          python -m conda_index ${{ env.GITHUB_WORKSPACE }}/channel
+          dir ${{ env.GITHUB_WORKSPACE }}\channel\win-64
 
-          # Test channel
+      - name: Index the channel
+        shell: cmd /C CALL {0}
+        run: conda index ${{ env.GITHUB_WORKSPACE }}\channel
+
+      - name: Dump mkl_random version info from created channel into ver.json
+        shell: cmd /C CALL {0}
+        run: |
           conda search ${{ env.PACKAGE_NAME }} -c ${{ env.GITHUB_WORKSPACE }}/channel --override-channels --info --json > ${{ env.GITHUB_WORKSPACE }}\ver.json
-          more ${{ env.GITHUB_WORKSPACE }}\ver.json
+
+      - name: Output content of produced ver.json
+        shell: pwsh
+        run: Get-Content -Path ${{ env.GITHUB_WORKSPACE }}\ver.json
 
       - name: Collect dependencies
         shell: cmd
         run: |
           @ECHO ON
-          copy /Y ${{ env.GITHUB_WORKSPACE }}\ver.json .
+          IF NOT EXIST ver.json (
+              copy /Y ${{ env.workdir }}\ver.json .
+          )
           set "SCRIPT=%VER_SCRIPT1% %VER_SCRIPT2%"
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -165,8 +165,8 @@ jobs:
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
 
-      - name: Install conda-build
-        run: conda install conda-build
+      - name: Install conda-index
+        run: conda install conda-index
 
       - name: Create conda channel
         run: |


### PR DESCRIPTION
With NumPy no longer on Intel channel, need to apply the same work-around as in conda-forge