### PR TITLE
Backport gh-137: Align with numpy 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Removed `numpy-base` dependency and `USE_NUMPY_BASE` environment variable from conda recipe [gh-124](https://github.com/IntelPython/mkl_random/pull/124)
 
+### Fixed
+* Fixed compatibility with NumPy 2.5 by replacing the deprecated in-place array `shape` assignment with `reshape`, and by replacing the deprecated `numpy.testing.suppress_warnings` usage in tests with `pytest.warns` [gh-137](https://github.com/IntelPython/mkl_random/pull/137)
+
 ## [1.4.1] (05/11/2026)
 
 ### Fixed

--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -591,7 +591,7 @@ cdef object vec_cont1_array(
         multi_shape = cpython.tuple.PyTuple_New(multi_nd)
         for i from 0 <= i < multi_nd:
             cpython.tuple.PyTuple_SetItem(multi_shape, i, multi_dims[i])
-        arr_obj.shape = (multi_shape + arr_obj.shape)[:arr_obj.ndim]
+        arr_obj = arr_obj.reshape((multi_shape + arr_obj.shape)[:arr_obj.ndim])
         multi_ndim = len(multi_shape)
         arr_obj = arr_obj.transpose(
             tuple(range(multi_ndim, arr_obj.ndim))
@@ -688,7 +688,7 @@ cdef object vec_cont2_array(
         multi_shape = cpython.tuple.PyTuple_New(multi_nd)
         for i from 0 <= i < multi_nd:
             cpython.tuple.PyTuple_SetItem(multi_shape, i, multi_dims[i])
-        arr_obj.shape = (multi_shape + arr_obj.shape)[:arr_obj.ndim]
+        arr_obj = arr_obj.reshape((multi_shape + arr_obj.shape)[:arr_obj.ndim])
         multi_ndim = len(multi_shape)
         arr_obj = arr_obj.transpose(
             tuple(range(multi_ndim, arr_obj.ndim))
@@ -800,7 +800,7 @@ cdef object vec_cont3_array(
         multi_shape = cpython.tuple.PyTuple_New(multi_nd)
         for i from 0 <= i < multi_nd:
             cpython.tuple.PyTuple_SetItem(multi_shape, i, multi_dims[i])
-        arr_obj.shape = (multi_shape + arr_obj.shape)[:arr_obj.ndim]
+        arr_obj = arr_obj.reshape((multi_shape + arr_obj.shape)[:arr_obj.ndim])
         multi_ndim = len(multi_shape)
         arr_obj = arr_obj.transpose(
             tuple(range(multi_ndim, arr_obj.ndim))
@@ -920,7 +920,7 @@ cdef object vec_discnp_array(
         multi_shape = cpython.tuple.PyTuple_New(multi_nd)
         for i from 0 <= i < multi_nd:
             cpython.tuple.PyTuple_SetItem(multi_shape, i, multi_dims[i])
-        arr_obj.shape = (multi_shape + arr_obj.shape)[:arr_obj.ndim]
+        arr_obj = arr_obj.reshape((multi_shape + arr_obj.shape)[:arr_obj.ndim])
         multi_ndim = len(multi_shape)
         arr_obj = arr_obj.transpose(
             tuple(range(multi_ndim, arr_obj.ndim))
@@ -1019,7 +1019,7 @@ cdef object vec_discdd_array(
         multi_shape = cpython.tuple.PyTuple_New(multi_nd)
         for i from 0 <= i < multi_nd:
             cpython.tuple.PyTuple_SetItem(multi_shape, i, multi_dims[i])
-        arr_obj.shape = (multi_shape + arr_obj.shape)[:arr_obj.ndim]
+        arr_obj = arr_obj.reshape((multi_shape + arr_obj.shape)[:arr_obj.ndim])
         multi_ndim = len(multi_shape)
         arr_obj = arr_obj.transpose(
             tuple(range(multi_ndim, arr_obj.ndim))
@@ -1137,7 +1137,7 @@ cdef object vec_discnmN_array(
         multi_shape = cpython.tuple.PyTuple_New(multi_nd)
         for i from 0 <= i < multi_nd:
             cpython.tuple.PyTuple_SetItem(multi_shape, i, multi_dims[i])
-        arr_obj.shape = (multi_shape + arr_obj.shape)[:arr_obj.ndim]
+        arr_obj = arr_obj.reshape((multi_shape + arr_obj.shape)[:arr_obj.ndim])
         multi_ndim = len(multi_shape)
         arr_obj = arr_obj.transpose(
             tuple(range(multi_ndim, arr_obj.ndim))
@@ -1243,7 +1243,9 @@ cdef object vec_discd_array(
                 func(state, n, array_data + n*i, oa_data[0])
                 cnp.PyArray_MultiIter_NEXTi(multi, 1)
         arr_obj = <object>array
-        arr_obj.shape = ((<object>oa).shape + arr_obj.shape)[:arr_obj.ndim]
+        arr_obj = arr_obj.reshape(
+            ((<object>oa).shape + arr_obj.shape)[:arr_obj.ndim]
+        )
         arr_obj = arr_obj.transpose(
             tuple(range(oa.ndim, arr_obj.ndim))
             + tuple(range(0, oa.ndim))
@@ -1302,7 +1304,9 @@ cdef object vec_long_discd_array(
                 func(state, n, array_data + n*i, oa_data[0])
                 cnp.PyArray_MultiIter_NEXTi(multi, 1)
         arr_obj = <object>array
-        arr_obj.shape = ((<object> oa).shape + arr_obj.shape)[:arr_obj.ndim]
+        arr_obj = arr_obj.reshape(
+            ((<object> oa).shape + arr_obj.shape)[:arr_obj.ndim]
+        )
         arr_obj = arr_obj.transpose(
             tuple(range(oa.ndim, arr_obj.ndim))
             + tuple(range(0, oa.ndim))
@@ -1355,9 +1359,9 @@ cdef object vec_Poisson_array(
                     func2(state, n, array_data + n*i, oa_data[0])
                     cnp.PyArray_MultiIter_NEXTi(multi, 1)
             arr_obj = <object>array
-            arr_obj.shape = (
+            arr_obj = arr_obj.reshape((
                 (<object>olambda).shape + arr_obj.shape
-            )[:arr_obj.ndim]
+            )[:arr_obj.ndim])
             arr_obj = arr_obj.transpose(
                 tuple(range(olambda.ndim, arr_obj.ndim))
                 + tuple(range(0, olambda.ndim))
@@ -6222,7 +6226,7 @@ cdef class _MKLRandomState:
 
         x = np.dot(x, np.sqrt(s)[:, None] * v)
         x += mean
-        x.shape = tuple(final_shape)
+        x = x.reshape(tuple(final_shape))
         return x
 
     def multinomial(self, int n, object pvals, size=None):

--- a/mkl_random/tests/test_random.py
+++ b/mkl_random/tests/test_random.py
@@ -34,7 +34,6 @@ from numpy.testing import (
     assert_equal,
     assert_no_warnings,
     assert_raises,
-    suppress_warnings,
 )
 
 import mkl_random as rnd
@@ -386,10 +385,8 @@ def test_randomdist_randint(randomdist):
 
 def test_randomdist_random_integers(randomdist):
     rnd.seed(randomdist.seed, brng=randomdist.brng)
-    with suppress_warnings() as sup:
-        w = sup.record(DeprecationWarning)
+    with pytest.warns(DeprecationWarning):
         actual = rnd.random_integers(-99, 99, size=(3, 2))
-        assert len(w) == 1
 
     desired = np.array([[96, -96], [-64, 42], [4, 97]])
     np.testing.assert_array_equal(actual, desired)
@@ -401,10 +398,8 @@ def test_random_integers_max_int():
     # into a C long. Previous implementations of this
     # method have thrown an OverflowError when attempting
     # to generate this integer.
-    with suppress_warnings() as sup:
-        w = sup.record(DeprecationWarning)
+    with pytest.warns(DeprecationWarning):
         actual = rnd.random_integers(np.iinfo("l").max, np.iinfo("l").max)
-        assert len(w) == 1
     desired = np.iinfo("l").max
     np.testing.assert_equal(actual, desired)
 


### PR DESCRIPTION
Backport of #137 to the `maintenance/1.4.x` branch.

NumPy 2.5 introduced two deprecations that broke the `mkl_random` test suite. This PR cherry-picks the fixes:

- **In-place array `shape` assignment** — NumPy 2.5 deprecated setting `arr.shape = (...)` in place. Replaced all such sites in `mkl_random/mklrand.pyx` with the equivalent `arr.reshape((...))`. The affected arrays are freshly-allocated C-contiguous buffers, so `reshape` returns a view (no copy) and behavior is unchanged.

- **`numpy.testing.suppress_warnings`** — deprecated in NumPy 2.4. Replaced the two usages in `mkl_random/tests/test_random.py` with `pytest.warns(DeprecationWarning)` and removed the now-unused import.

Cherry-picked commits `c27f265`, `a1f7b3f`, `aee582c` from #137. The changelog entry was adapted to the `[dev]` section of the 1.4.x branch (only the gh-137 fix; unrelated master-only entries were excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
