### PR TITLE
Backport gh-124: remove numpy-base toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [dev] (MM/DD/YYYY)
+
+### Changed
+* Removed `numpy-base` dependency and `USE_NUMPY_BASE` environment variable from conda recipe [gh-124](https://github.com/IntelPython/mkl_random/pull/124)
+
 ## [1.4.1] (05/11/2026)
 
 ### Fixed

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,3 @@
-# Intel numpy-base is still needed for internal wheels CI, so we control its use with this optional toggle
-{% set use_numpy_base = environ.get('USE_NUMPY_BASE', 'true').lower() == 'true' %}
-
 package:
     name: mkl_random
     version: {{ GIT_DESCRIBE_TAG }}
@@ -26,22 +23,14 @@ requirements:
       - setuptools >=77
       - mkl-devel
       - cython
-      {% if use_numpy_base %}
-      - numpy-base
-      {% else %}
       - numpy
-      {% endif %}
       - pip
       - wheel  >=0.41.3
     run:
       - python
       - python-gil     # [py>=314]
       - {{ pin_compatible('mkl', min_pin="x.x", max_pin="x") }}
-      {% if use_numpy_base %}
-      - numpy-base
-      {% else %}
       - numpy >=1.26.4
-      {% endif %}
 
 test:
     commands:


### PR DESCRIPTION
Backport of #124 to the `maintenance/1.4.x` branch.

Removes the `numpy-base` dependency and the `USE_NUMPY_BASE` environment-variable toggle from the conda recipe ([conda-recipe/meta.yaml](conda-recipe/meta.yaml)), replacing `numpy-base` with plain `numpy` (`numpy >=1.26.4` at runtime).

### Why this is needed on 1.4.x

CI on the 1.4.x release prep (#141) fails at conda environment creation for `test_linux (3.10, 2.2)` — the solver cannot satisfy the `numpy-base` constraints against the currently-available `mkl` / `tbb` / `python_abi` builds. Dropping the `numpy-base` toggle in favor of plain `numpy` resolves the environment, matching what master already does.

Cherry-picked commit `a1c7dd5` from #124; the changelog entry was adapted to the `[dev]` section of the 1.4.x branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
