### PR TITLE
Add OpenSSF Scorecard workflow and badge

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -1,0 +1,74 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '28 2 * * 1'
+    - cron: '28 2 * * 4'
+  push:
+    branches: [ "master" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 14
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## `mkl_random` -- a NumPy-based Python interface to Intel® oneAPI Math Kernel Library (OneMKL) Random Number Generation functionality
 [![Conda package using conda-forge](https://github.com/IntelPython/mkl_random/actions/workflows/conda-package-cf.yml/badge.svg)](https://github.com/IntelPython/mkl_random/actions/workflows/conda-package-cf.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/IntelPython/mkl_random/badge)](https://securityscorecards.dev/viewer/?uri=github.com/IntelPython/mkl_random)
 
 `mkl_random` started as a part of Intel® Distribution for Python optimizations to NumPy.
 


### PR DESCRIPTION
## Summary

Adds the OpenSSF Scorecard workflow and the corresponding README badge, aligning `mkl_random` with the other projects in the org.

`mkl_random` is currently the only one of these repositories without `.github/workflows/openssf-scorecard.yml`:

| Repository | `openssf-scorecard.yml` | Scorecard |
|---|---|---|
| dpctl | yes | 8.2 |
| dpnp | yes | 8.5 |
| mkl_umath | yes | 8.1 |
| mkl_fft | yes | 8.2 |
| **mkl_random** | **no** | **7.3** |

## Why it matters beyond the badge

Running the analysis from within the repository lets Scorecard evaluate checks that an external scan cannot see. The published report for `mkl_random` contains **14 checks, while the other four report 18** — missing are `CI-Tests`, `Contributors`, `Dependency-Update-Tool` and `Vulnerabilities`, even though `.github/dependabot.yml` is present and CI is extensive.

Those four checks would score well here, so simply having them evaluated raises the aggregate score without any change to the codebase.

## Notes

- The workflow is copied **verbatim** from `mkl_fft`, so every action stays pinned by commit hash and the four projects remain consistent.
- Top-level `permissions: read-all`; the elevated `security-events: write` / `id-token: write` are scoped to the job, matching the other repositories, so `Token-Permissions` and `Dangerous-Workflow` are unaffected.
- The `Upload to code-scanning` step publishes Scorecard's own SARIF findings to the Security tab (these are Scorecard results, not code vulnerabilities), same as in the sibling projects. Happy to drop that step if it is not wanted — it does not affect the score.

## Related, applied separately via repository rulesets

- `maintenance/1.4.x` had no branch protection at all; it now carries the same rules as `master` (this branch is the target of the 1.4.2 release).
- `master` now requires branches to be up to date before merging. Its required status checks were configured but earning no points, because Scorecard's tier evaluation stops early and the unmet tier 2 was suppressing tier 3.

Together these take `Branch-Protection` from 1 to an expected 8.
