### PR TITLE
Define PACKAGE_NAME env var in build-docs workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,6 +7,9 @@ on:
 
 permissions: read-all
 
+env:
+  PACKAGE_NAME: mkl_random
+
 jobs:
   build-and-deploy:
     name: Build and Deploy Documentation


### PR DESCRIPTION
## Summary

The `Save built docs as an artifact` step in `build-docs.yml` names the artifact using `${{ env.PACKAGE_NAME }}`:

```yaml
- name: Save built docs as an artifact
  ...
  with:
    name: ${{ env.PACKAGE_NAME }} rendered documentation
```

However, `PACKAGE_NAME` is never defined in this workflow (no `env:` block at the workflow, job, or step level). The expression expands to an empty string, so the uploaded artifact is named `" rendered documentation"` with a leading space.

## Change

Define `PACKAGE_NAME: mkl_random` at the workflow level, matching the convention already used in `conda-package.yml` and `conda-package-cf.yml`. The artifact is now correctly named `mkl_random rendered documentation`.