### PR TITLE
Fix constant integer overflow in irk_rand_uint32_vec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed compatibility with NumPy 2.5 by replacing the deprecated in-place array `shape` assignment with `reshape`, and by replacing the deprecated `numpy.testing.suppress_warnings` usage in tests with `pytest.warns` [gh-137](https://github.com/IntelPython/mkl_random/pull/137)
+* Fixed a constant integer overflow in `irk_rand_uint32_vec` by declaring the `shift` variable as `npy_uint32` instead of `npy_int32`, so `2**31` no longer overflows a signed 32-bit integer (behavior is unchanged as all downstream uses rely on modulo-2^32 arithmetic)
 
 ## [1.4.1] (05/11/2026)
 

--- a/mkl_random/src/mkl_distributions.cpp
+++ b/mkl_random/src/mkl_distributions.cpp
@@ -1981,7 +1981,7 @@ void irk_rand_uint32_vec(irk_state *state,
 
     if (hi >= intm) {
 
-        npy_int32 shift = ((npy_uint32)intm) + ((npy_uint32)1);
+        npy_uint32 shift = ((npy_uint32)intm) + ((npy_uint32)1);
         int i;
 
         /* if lo is non-zero, shift one more to accommodate possibility of hi


### PR DESCRIPTION
## Summary

Fixes Coverity `INTEGER_OVERFLOW` in `irk_rand_uint32_vec` in `mkl_random/src/mkl_distributions.cpp`.

The `shift` variable was declared as `npy_int32`, but its initializer:

```c
npy_int32 shift = ((npy_uint32)intm) + ((npy_uint32)1);  // intm = INT_MAX
```

evaluates to `2**31 = 2147483648`, which does not fit in a signed 32-bit integer. Storing it wrapped to `INT32_MIN` — an out-of-range signed conversion that Coverity flags as an overflowed constant.

## Fix

Declare `shift` as `npy_uint32`. Both `2**31` and `2**31 + 1` (the `if (lo) shift++;` case) fit in an unsigned 32-bit integer, so the overflow disappears.
