### PR TITLE
Fix unreachable scalar fast-path in `RandomState.uniform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed compatibility with NumPy 2.5 by replacing the deprecated in-place array `shape` assignment with `reshape`, and by replacing the deprecated `numpy.testing.suppress_warnings` usage in tests with `pytest.warns` [gh-137](https://github.com/IntelPython/mkl_random/pull/137)
 * Fixed a constant integer overflow in `irk_rand_uint32_vec` by declaring the `shift` variable as `npy_uint32` instead of `npy_int32`, so `2**31` no longer overflows a signed 32-bit integer (behavior is unchanged as all downstream uses rely on modulo-2^32 arithmetic) [gh-156](https://github.com/IntelPython/mkl_random/pull/156)
+* Fixed `uniform` to return a Python `float` for scalar bounds with `size=None` instead of a 0-d array [gh-167](https://github.com/IntelPython/mkl_random/pull/167)
+
 
 ## [1.4.1] (05/11/2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+* Fixed `uniform` to return a Python `float` for scalar bounds with `size=None` instead of a 0-d array [gh-167](https://github.com/IntelPython/mkl_random/pull/167)
 
 ## [1.5.0] (08/12/2026)
 
@@ -24,8 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed compatibility with NumPy 2.5 by replacing the deprecated in-place array `shape` assignment with `reshape`, and by replacing the deprecated `numpy.testing.suppress_warnings` usage in tests with `pytest.warns` [gh-137](https://github.com/IntelPython/mkl_random/pull/137)
 * Fixed a constant integer overflow in `irk_rand_uint32_vec` by declaring the `shift` variable as `npy_uint32` instead of `npy_int32`, so `2**31` no longer overflows a signed 32-bit integer (behavior is unchanged as all downstream uses rely on modulo-2^32 arithmetic) [gh-156](https://github.com/IntelPython/mkl_random/pull/156)
-* Fixed `uniform` to return a Python `float` for scalar bounds with `size=None` instead of a 0-d array [gh-167](https://github.com/IntelPython/mkl_random/pull/167)
-
 
 ## [1.4.1] (05/11/2026)
 

--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -2534,14 +2534,14 @@ cdef class _MKLRandomState:
             if flow >= fhigh:
                 raise ValueError("low >= high")
 
-                return vec_cont2_array_sc(
-                    self.internal_state,
-                    irk_uniform_vec,
-                    size,
-                    flow,
-                    fhigh,
-                    self.lock
-                )
+            return vec_cont2_array_sc(
+                self.internal_state,
+                irk_uniform_vec,
+                size,
+                flow,
+                fhigh,
+                self.lock
+            )
 
         if not np.all(np.isfinite(olow)) or not np.all(np.isfinite(ohigh)):
             raise OverflowError("Range exceeds valid bounds")

--- a/mkl_random/mklrand.pyx
+++ b/mkl_random/mklrand.pyx
@@ -2471,7 +2471,7 @@ cdef class _MKLRandomState:
 
         Returns
         -------
-        out : ndarray
+        out : ndarray or scalar
             Drawn samples, with shape `size`.
 
         See Also

--- a/mkl_random/tests/test_random.py
+++ b/mkl_random/tests/test_random.py
@@ -1142,12 +1142,22 @@ def test_uniform_range_bounds():
     rnd.uniform(low=fmin, high=fmax / 1e17)
 
 
-def test_uniform_return_type():
-    val = rnd.uniform(0.0, 1.0)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (0.0, 1.0),
+        (np.float64(0.0), np.float64(1.0)),
+        (np.array(0.0), np.array(1.0)),
+    ],
+)
+def test_uniform_return_type(low, high):
+    val = rnd.uniform(low, high)
     assert np.isscalar(val), f"expected a scalar, got {type(val)}"
     assert isinstance(val, float)
     assert 0.0 <= val < 1.0
 
+
+def test_uniform_array_bounds_return_ndarray():
     arr = rnd.uniform([0.0, 10.0], [1.0, 11.0])
     assert isinstance(arr, np.ndarray)
     assert arr.shape == (2,)

--- a/mkl_random/tests/test_random.py
+++ b/mkl_random/tests/test_random.py
@@ -1142,6 +1142,17 @@ def test_uniform_range_bounds():
     rnd.uniform(low=fmin, high=fmax / 1e17)
 
 
+def test_uniform_return_type():
+    val = rnd.uniform(0.0, 1.0)
+    assert np.isscalar(val), f"expected a scalar, got {type(val)}"
+    assert isinstance(val, float)
+    assert 0.0 <= val < 1.0
+
+    arr = rnd.uniform([0.0, 10.0], [1.0, 11.0])
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (2,)
+
+
 def test_randomdist_vonmises(randomdist):
     rnd.seed(randomdist.seed, brng=randomdist.brng)
     actual = rnd.vonmises(mu=1.23, kappa=1.54, size=(3, 2))


### PR DESCRIPTION
This PR fixes a scalar fast-path in `RandomState.uniform` that was never reached. 
The `vec_cont2_array_sc(...)` call was wrongly indented inside the if `flow >= fhigh` block, so scalar bounds fell through to the array path and returned `0-d ndarray` instead of a `Python float`

```
import mkl_random

# Before
mkl_random.uniform(0.0, 1.0)
# array(0.13436424)

# Now
mkl_random.uniform(0.0, 1.0)
# 0.13436424476094544
```